### PR TITLE
Fix missing new line when adding excluded files

### DIFF
--- a/module.py
+++ b/module.py
@@ -47,6 +47,7 @@ class Module(ABC):
 
         with open(self.excluded_filelist, "a") as f:
             f.write("\n".join(paths))
+            f.write("\n")
 
     def get_excluded_files(self) -> set[str]:
         if self.excluded_enable == False:


### PR DESCRIPTION
I noticed the file tracking exclusions often had 2 files on the same line, and I think that's because one run appends files but doesn't add another new line at the very end, so the next run starts appending at the end of the line from the previous run.