### PR TITLE
Fix unnecessary new lines in exclusion files

### DIFF
--- a/module.py
+++ b/module.py
@@ -43,6 +43,9 @@ class Module(ABC):
         return self.excluded_enable and self.excluded_append
 
     def add_excluded_files(self, paths: list[str]):
+        if len(paths) == 0:
+            return
+
         logger.info(f"Adding {len(paths)} files to excluded")
 
         with open(self.excluded_filelist, "a") as f:


### PR DESCRIPTION
Related to my previous PR, which did fix having multiple paths on the same line, but now every run writes empty lines which aren't necessary if the list of processed files is empty.