### PR TITLE
Fix duplicate subtitles with different extensions

### DIFF
--- a/extract/constants.py
+++ b/extract/constants.py
@@ -2,29 +2,13 @@
 Constants for subtitle extraction.
 """
 
-FFMPEG_TEXT_FORMATS = (
-    "arib_caption",
-    "ass",
-    "eia_608",
-    "hdmv_text_subtitle",
-    "jacosub",
-    "microdvd",
-    "mov_text",
-    "mpl2",
-    "pjs",
-    "realtext",
-    "sami",
-    "srt",
-    "ssa",
-    "stl",
-    "subrip",
-    "subviewer",
-    "subviewer1",
-    "text",
-    "ttml",
-    "vplayer",
-    "webvtt",
-)
+FFMPEG_TEXT_FORMATS = {
+    "srt": ["srt", "subrip", "mov_text"],
+    "ass": ["ass", "ssa"],
+    "vtt": ["webvtt"],
+    "ttml": ["ttml"],
+}
+
 
 FFMPEG_BITMAP_FORMATS = [
     "dvb_subtitle",

--- a/extract/extractors/base.py
+++ b/extract/extractors/base.py
@@ -23,7 +23,7 @@ class BaseExtractor(ABC):
         self.media_prober = media_probe
 
     @abstractmethod
-    def extract(self, video_path: str, streams: list[StreamInfo]) -> list[str]:
+    def extract(self, video_path: str) -> list[str]:
         """
         Extract subtitles from video file.
 
@@ -70,8 +70,8 @@ class BaseExtractor(ABC):
             return False
 
         # Check codec support
-        if supported_codecs and stream.codec_name not in supported_codecs:
-            logger.warning(
+        if stream.codec_name not in supported_codecs:
+            logger.debug(
                 f"Skipping unsupported codec '{stream.codec_name}' for stream {stream.index}"
             )
             return False

--- a/extract/extractors/text.py
+++ b/extract/extractors/text.py
@@ -2,17 +2,18 @@
 Text-based subtitle extractor using FFmpeg.
 """
 
+import itertools
 import logging
 import os
 
 from ..constants import FFMPEG_TEXT_FORMATS
 from ..exceptions import FFmpegError
 from ..path import SubtitlePath
-from ..prober import StreamInfo
-from .base import BaseExtractor
 from ..subprocess import SubprocessError
+from .base import BaseExtractor
 
 logger = logging.getLogger(__name__)
+_CODECS = list(itertools.chain.from_iterable(FFMPEG_TEXT_FORMATS.values()))
 
 
 class TextSubtitleExtractor(BaseExtractor):
@@ -29,14 +30,14 @@ class TextSubtitleExtractor(BaseExtractor):
         Returns:
             List of paths to extracted subtitle files
         """
-        logger.debug(f"Extracting text subtitles from {video_path}")
+        logger.info(f"Extracting text subtitles from: {video_path}")
 
         streams = self.media_prober.get_subtitle_streams(
             video_path, self.config.unknown_language_as
         )
 
         # Filter streams by supported codecs
-        text_streams = self.filter_streams_by_codec(streams, FFMPEG_TEXT_FORMATS)
+        text_streams = self.filter_streams_by_codec(streams, _CODECS)
 
         if not text_streams:
             logger.debug("No text-based subtitle streams found")
@@ -52,7 +53,7 @@ class TextSubtitleExtractor(BaseExtractor):
                 output_path = path_manager.generate_subtitle_path(stream, fmt)
 
                 if self.should_extract_stream(
-                    video_path, stream, output_path, FFMPEG_TEXT_FORMATS
+                    video_path, stream, output_path, FFMPEG_TEXT_FORMATS.get(fmt, [])
                 ):
                     ffmpeg_args.extend(["-map", f"0:{stream.index}", output_path])
                     output_paths.append(output_path)
@@ -62,7 +63,6 @@ class TextSubtitleExtractor(BaseExtractor):
                 self._run_ffmpeg_extraction(video_path, ffmpeg_args)
                 logger.info(f"Extracted {len(output_paths)} text-based subtitle files")
             except:
-
                 for p in output_path:
                     if os.path.exists(p) and os.path.getsize(p) == 0:
                         os.remove(p)


### PR DESCRIPTION
Hi, I noticed some subtitle file duplicates after extraction, which happened because of the loop over the desired extensions:

- If `srt` was desired, *every* supported subtitle stream was extracted and saved with that extension.
- If `ass` was also desired, the same happened, overlapping with the subs extracted previously but now with a different extension.

I did a quick fix with a dict of extensions to supported codecs, but I only included the ones that still seem relevant, not sure what you think about that.